### PR TITLE
Using Material Scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,47 @@ If you are pushing a new `modal` screen, use the following function:
 
 - To push bottom sheet on top of the Navigation Bar, use showModalBottomScreen and set it's property `useRootNavigator` to true. See example project for an illustration.
 
+## Floating Action Buttons & App Bars
+### Floating Action Buttons
+You can configure a floating action button that will sit above the navigation bar on the side of the screen by using `persistentFloatingActionButton`. This will stay floating when animating between screens, and replaces the now removed ~`floatingActionButton`~ property. Pass in a widget to this property (usually a `FloatingActionButton`), and it'll work out of the box.
+
+If you need a particular FAB on one screen, wrap that screen's widget in another `Scaffold` and use the `floatingActionButton` property there. You'll need to add some bottom padding (wrap the `FloatingActionButton` in `Padding`) to move it out of the way of the `persistentFloatingActionButton` if one has been specified; you can use `66` logical pixels if using the default bar height.
+
+One advanced setup would be to have the FAB expanded on the first screen, and standard size on all the others. This can be done using the code below:
+```dart
+FloatingActionButton.extended(
+  onPressed: () {},
+  isExtended: pageController.index == 0,
+  label: AnimatedSwitcher(
+    duration: Duration(milliseconds: 300),
+    transitionBuilder: (Widget child, Animation<double> animation) =>
+      FadeTransition(
+        opacity: animation,
+        child: SizeTransition(
+          child: child,
+          sizeFactor: animation,
+          axis: Axis.horizontal,
+        ),
+      ),
+    child: pageController.index != 0
+      ? Icon(Icons.ac_unit)
+      : Row(
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(right: 6.0),
+            child: Icon(Icons.ac_unit)
+          ),
+          Text('AC UNIT')
+        ],
+     ),
+  ),
+),
+```
+### App Bar
+You can configure an app bar that will strech at the top of the screen using `persistentAppBar`. This will stay floating when animating between screens. Pass in a `PrefferedSizeWidget` widget to this property (usually an `AppBar`), and it'll work out of the box.
+
+If you need a particular app bar on one screen, wrap that screen's widget in another `Scaffold` and use the `appBar` property there. Because the `persistentAppBar` takes up space if it has been setup, any app bar in each screen will automatically position itself below the `persistentAppBar`.
+
 ## Custom Navigation Bar Styling
 
 If you want to have your own style for the navigation bar, follow these steps:

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -609,7 +609,7 @@ class _PersistentTabViewState extends State<PersistentTabView> {
         floatingActionButton: widget.floatingActionButton,
         resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,
         backgroundColor: Colors.transparent,
-        child: PersistentTabScaffold(
+        body: PersistentTabScaffold(
           controller: _controller,
           itemCount: widget.items == null
               ? widget.itemCount ?? 0

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -605,7 +605,8 @@ class _PersistentTabViewState extends State<PersistentTabView> {
                     return Material(elevation: 0, child: widget.screens[index]);
                   });
 
-  Widget navigationBarWidget() => CupertinoPageScaffold(
+  Widget navigationBarWidget() => Scaffold(
+        floatingActionButton: widget.floatingActionButton,
         resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,
         backgroundColor: Colors.transparent,
         child: PersistentTabScaffold(

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -18,8 +18,13 @@ class PersistentTabView extends PersistentTabViewBase {
   final Color backgroundColor;
 
   ///A custom widget which is displayed at the bottom right of the display at all times.
+  ///
+  ///Only want the floatingActionButton on certain screens? Use another Scaffold around the widget in the `screens` property, and use the `floatingActionButton` there. Note that that FAB will be displayed near/under this persistent FAB if this is specified: use a Padding widget to move it up so it is visible.
   final Widget persistentFloatingActionButton;
   
+  ///A widget (usually AppBar) which is displayed like the app bar at all times.
+  ///
+  ///Only want the app bar on certain screens? Use another Scaffold around the widget in the `screens` property, and use the `appBar` there. Note that that AppBar will be displayed under this persistent app bar if this is specified.
   final PreferredSizeWidget persistentAppBar;
 
   ///Specifies the navBarHeight
@@ -237,9 +242,14 @@ class PersistentTabViewBase extends StatefulWidget {
   final NeumorphicProperties neumorphicProperties;
 
   ///A custom widget which is displayed at the bottom right of the display at all times.
+  ///
+  ///Only want the floatingActionButton on certain screens? Use another Scaffold around the widget in the `screens` property, and use the `floatingActionButton` there. Note that that FAB will be displayed near/under this persistent FAB if this is specified: use a Padding widget to move it up so it is visible.
   final Widget persistentFloatingActionButton;
   
-  final Widget persistentAppBar;
+  ///A widget (usually AppBar) which is displayed like the app bar at all times.
+  ///
+  ///Only want the app bar on certain screens? Use another Scaffold around the widget in the `screens` property, and use the `appBar` there. Note that that AppBar will be displayed under this persistent app bar if this is specified.
+  final PreferredSizeWidget persistentAppBar;
 
   ///Specifies the navBarHeight
   ///
@@ -415,15 +425,6 @@ class _PersistentTabViewState extends State<PersistentTabView> {
                 },
               ),
             ),
-            /*
-            OLD METHOD OF ADDING FLOATING ACTION BUTTON
-            Positioned(
-              bottom: widget.decoration.borderRadius != BorderRadius.zero
-                  ? 25.0
-                  : 10.0,
-              right: 10.0,
-              child: widget.persistentFloatingActionButton,
-            ),*/
           ],
         )
       : widget.navBarStyle == NavBarStyle.style15
@@ -618,7 +619,7 @@ class _PersistentTabViewState extends State<PersistentTabView> {
 
   Widget navigationBarWidget() => Scaffold(
         floatingActionButton: Padding(
-          padding: EdgeInsets.only(bottom: widget.navBarHeight + 5),
+          padding: EdgeInsets.only(bottom: widget.navBarHeight + 2),
           child: widget.persistentFloatingActionButton,
         ),
         appBar: widget.persistentAppBar,

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -22,9 +22,9 @@ class PersistentTabView extends PersistentTabViewBase {
   ///Only want the floatingActionButton on certain screens? Use another Scaffold around the widget in the `screens` property, and use the `floatingActionButton` there. Note that that FAB will be displayed near/under this persistent FAB if this is specified: use a Padding widget to move it up so it is visible.
   final Widget persistentFloatingActionButton;
   
-  ///A widget (usually AppBar) which is displayed like the app bar at all times.
+  ///A PreferredSizeWidget widget (usually AppBar) which is displayed like the app bar at all times.
   ///
-  ///Only want the app bar on certain screens? Use another Scaffold around the widget in the `screens` property, and use the `appBar` there. Note that that AppBar will be displayed under this persistent app bar if this is specified.
+  ///Only want the app bar on certain screens? Use another Scaffold around the widget in the `screens` property, and use the `appBar` there. Note that that AppBar will be automatically moved below this persistent app bar if this is specified, resulting in a double AppBar.
   final PreferredSizeWidget persistentAppBar;
 
   ///Specifies the navBarHeight
@@ -241,14 +241,14 @@ class PersistentTabViewBase extends StatefulWidget {
   ///Works only with style `neumorphic`.
   final NeumorphicProperties neumorphicProperties;
 
-  ///A custom widget which is displayed at the bottom right of the display at all times.
+///A custom widget which is displayed at the bottom right of the display at all times.
   ///
   ///Only want the floatingActionButton on certain screens? Use another Scaffold around the widget in the `screens` property, and use the `floatingActionButton` there. Note that that FAB will be displayed near/under this persistent FAB if this is specified: use a Padding widget to move it up so it is visible.
   final Widget persistentFloatingActionButton;
   
-  ///A widget (usually AppBar) which is displayed like the app bar at all times.
+  ///A PreferredSizeWidget widget (usually AppBar) which is displayed like the app bar at all times.
   ///
-  ///Only want the app bar on certain screens? Use another Scaffold around the widget in the `screens` property, and use the `appBar` there. Note that that AppBar will be displayed under this persistent app bar if this is specified.
+  ///Only want the app bar on certain screens? Use another Scaffold around the widget in the `screens` property, and use the `appBar` there. Note that that AppBar will be automatically moved below this persistent app bar if this is specified, resulting in a double AppBar.
   final PreferredSizeWidget persistentAppBar;
 
   ///Specifies the navBarHeight

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -151,6 +151,7 @@ class PersistentTabView extends PersistentTabViewBase {
     this.controller,
     this.margin = EdgeInsets.zero,
     this.persistentFloatingActionButton,
+    this.persistentAppBar,
     Widget customWidget,
     int itemCount,
     this.resizeToAvoidBottomInset = false,
@@ -174,6 +175,7 @@ class PersistentTabView extends PersistentTabViewBase {
           routeAndNavigatorSettings: routeAndNavigatorSettings,
           backgroundColor: backgroundColor,
           persistentFloatingActionButton: persistentFloatingActionButton,
+          persistentAppBar: persistentAppBar,
           customWidget: customWidget,
           itemCount: itemCount,
           resizeToAvoidBottomInset: resizeToAvoidBottomInset,
@@ -236,6 +238,8 @@ class PersistentTabViewBase extends StatefulWidget {
 
   ///A custom widget which is displayed at the bottom right of the display at all times.
   final Widget persistentFloatingActionButton;
+  
+  final Widget persistentAppBar;
 
   ///Specifies the navBarHeight
   ///
@@ -306,6 +310,7 @@ class PersistentTabViewBase extends StatefulWidget {
     this.screens,
     this.controller,
     this.persistentFloatingActionButton,
+    this.persistentAppBar,
     this.margin,
     this.confineInSafeArea,
     this.handleAndroidBackButtonPress,

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -18,7 +18,9 @@ class PersistentTabView extends PersistentTabViewBase {
   final Color backgroundColor;
 
   ///A custom widget which is displayed at the bottom right of the display at all times.
-  final Widget floatingActionButton;
+  final Widget persistentFloatingActionButton;
+  
+  final PreferredSizeWidget persistentAppBar;
 
   ///Specifies the navBarHeight
   ///
@@ -75,7 +77,8 @@ class PersistentTabView extends PersistentTabViewBase {
       this.backgroundColor = CupertinoColors.white,
       ValueChanged<int> onItemSelected,
       NeumorphicProperties neumorphicProperties,
-      this.floatingActionButton,
+      this.persistentFloatingActionButton,
+      this.persistentAppBar,
       NavBarPadding padding = const NavBarPadding.all(null),
       NavBarDecoration decoration = const NavBarDecoration(),
       this.resizeToAvoidBottomInset = false,
@@ -113,7 +116,8 @@ class PersistentTabView extends PersistentTabViewBase {
           backgroundColor: backgroundColor,
           onItemSelected: onItemSelected,
           neumorphicProperties: neumorphicProperties,
-          floatingActionButton: floatingActionButton,
+          persistentFloatingActionButton: persistentFloatingActionButton,
+          persistentAppBar: persistentAppBar,
           resizeToAvoidBottomInset: resizeToAvoidBottomInset,
           bottomScreenMargin: bottomScreenMargin,
           onWillPop: onWillPop,
@@ -146,7 +150,7 @@ class PersistentTabView extends PersistentTabViewBase {
     @required this.screens,
     this.controller,
     this.margin = EdgeInsets.zero,
-    this.floatingActionButton,
+    this.persistentFloatingActionButton,
     Widget customWidget,
     int itemCount,
     this.resizeToAvoidBottomInset = false,
@@ -169,7 +173,7 @@ class PersistentTabView extends PersistentTabViewBase {
           margin: margin,
           routeAndNavigatorSettings: routeAndNavigatorSettings,
           backgroundColor: backgroundColor,
-          floatingActionButton: floatingActionButton,
+          persistentFloatingActionButton: persistentFloatingActionButton,
           customWidget: customWidget,
           itemCount: itemCount,
           resizeToAvoidBottomInset: resizeToAvoidBottomInset,
@@ -231,7 +235,7 @@ class PersistentTabViewBase extends StatefulWidget {
   final NeumorphicProperties neumorphicProperties;
 
   ///A custom widget which is displayed at the bottom right of the display at all times.
-  final Widget floatingActionButton;
+  final Widget persistentFloatingActionButton;
 
   ///Specifies the navBarHeight
   ///
@@ -301,7 +305,7 @@ class PersistentTabViewBase extends StatefulWidget {
     Key key,
     this.screens,
     this.controller,
-    this.floatingActionButton,
+    this.persistentFloatingActionButton,
     this.margin,
     this.confineInSafeArea,
     this.handleAndroidBackButtonPress,
@@ -382,7 +386,7 @@ class _PersistentTabViewState extends State<PersistentTabView> {
     }
   }
 
-  Widget _buildScreen(int index) => widget.floatingActionButton != null
+  Widget _buildScreen(int index) => widget.persistentFloatingActionButton != null
       ? Stack(
           fit: StackFit.expand,
           children: <Widget>[
@@ -406,13 +410,15 @@ class _PersistentTabViewState extends State<PersistentTabView> {
                 },
               ),
             ),
+            /*
+            OLD METHOD OF ADDING FLOATING ACTION BUTTON
             Positioned(
               bottom: widget.decoration.borderRadius != BorderRadius.zero
                   ? 25.0
                   : 10.0,
               right: 10.0,
-              child: widget.floatingActionButton,
-            ),
+              child: widget.persistentFloatingActionButton,
+            ),*/
           ],
         )
       : widget.navBarStyle == NavBarStyle.style15
@@ -606,7 +612,11 @@ class _PersistentTabViewState extends State<PersistentTabView> {
                   });
 
   Widget navigationBarWidget() => Scaffold(
-        floatingActionButton: widget.floatingActionButton,
+        floatingActionButton: Padding(
+          padding: EdgeInsets.only(bottom: widget.navBarHeight + 5),
+          child: widget.persistentFloatingActionButton,
+        ),
+        appBar: widget.persistentAppBar,
         resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,
         backgroundColor: Colors.transparent,
         body: PersistentTabScaffold(


### PR DESCRIPTION
This pull request changes the internal scaffold to use the standard Material scaffold instead of the Cupertino scaffold. This allows better support for:

- Floating Action Buttons
The `floatingActionButton` property has changed to `persistentFloatingActionButton`. The widget found in here will be put in the new parent Material scaffold, resulting in the effect of the FAB not moving with the page transition, hence making it truly floating. If the developer wants a FAB on an individual screen, they can wrap the screen with another scaffold and use the FAB widget there, although padding will be required if there is a `persistentFloatingActionButton` to move it out of the way. The IntelliSense documentation has been changed to reflect this. **BE AWARE: this is a breaking change.**
- App Bars
Similarly to the new FAB implementation, a new constructor property `persistentAppBar` has been added. This app bar stays still when the pages are transitioning, instead of moving with each screen. If the developer wants an app bar on an individual screen, they can wrap the screen with another scaffold and use the AppBar widget there. Because the AppBar takes up space from each screen, any app bar specified in an inner scaffold (like suggested in the last sentence) will be automatically moved below the `persistentAppBar`, if specified. The IntelliSense documentation has been changed to reflect this. _This change could have been made without changing the scaffold type._

I recommend looking over the new code before merging this because I have likely left some now unnecessary code in, potentially from line 404, because I do not want to break the code (commits are being made through GitHubs internal editor, so I have no error checking or IntelliSense etc.).

I am not the best developer, but I hope this code is appreciated :).

Thanks,
Luka S.